### PR TITLE
fix compile failed bug

### DIFF
--- a/iguana/json.hpp
+++ b/iguana/json.hpp
@@ -274,7 +274,7 @@ namespace iguana { namespace json
             bool neg = false;
         };
 
-        bool g_has_error = false;
+        static bool g_has_error = false;
         class reader_t {
         public:
             reader_t(const char *ptr = nullptr, size_t len = -1) : ptr_((char *)ptr), len_(len) {

--- a/iguana/reflection.hpp
+++ b/iguana/reflection.hpp
@@ -317,7 +317,7 @@ namespace iguana::detail {
     MACRO_CONCAT(CON_STR, GET_ARG_COUNT(__VA_ARGS__))(__VA_ARGS__)
 
 #define MAKE_META_DATA_IMPL(STRUCT_NAME, ...) \
-auto iguana_reflect_members(STRUCT_NAME const&) \
+static auto iguana_reflect_members(STRUCT_NAME const&) \
 { \
     struct reflect_members \
     { \


### PR DESCRIPTION
In the follow demo, the compile failed with g_has_error, iguana_reflect_members has declared in xxx.o.

demo.h
struct demo
{
 int a;
int b;
}
REFLECTION(demo, a,b)
void test_func(demo a);

demo.cpp
#inlude "demo.h"
void test_func(demo a)
{
 iguana::string_stream ss;
 iguana::json::to_json(ss, a);
}

main.cpp
#include "demo.h"
int main(void)
{
 demo d{1,2};
 test_func(d);
return 0;
}
It also happened on Ubuntu.
I fixed it with the suggestions in 
https://msdn.microsoft.com/en-us/library/72zdcz6f.aspx