### PR TITLE
修复json中\u中文无效的bug

### DIFF
--- a/iguana/json.hpp
+++ b/iguana/json.hpp
@@ -516,15 +516,18 @@ namespace iguana { namespace json
 
                 if (utf1 < 0x80) {
                     fill_escape_char(esc_count, (char)utf1);
+                    esc_count -= 1;
                 }
                 else if (utf1 < 0x800) {
                     fill_escape_char(esc_count, (char)(0xC0 | ((utf1 >> 6) & 0xFF)));
                     fill_escape_char(esc_count - 1, (char)(0x80 | ((utf1 & 0x3F))));
+                    esc_count -= 2;
                 }
                 else if (utf1 < 0x80000) {
                     fill_escape_char(esc_count, (char)(0xE0 | ((utf1 >> 12) & 0xFF)));
                     fill_escape_char(esc_count - 1, (char)(0x80 | ((utf1 >> 6) & 0x3F)));
                     fill_escape_char(esc_count - 2, (char)(0x80 | ((utf1 & 0x3F))));
+                    esc_count -= 3;
                 }
                 else {
                     if (utf1 < 0x110000) {
@@ -534,6 +537,7 @@ namespace iguana { namespace json
                     fill_escape_char(esc_count - 1, (char)(0x80 | ((utf1 >> 12) & 0x3F)));
                     fill_escape_char(esc_count - 2, (char)(0x80 | ((utf1 >> 6) & 0x3F)));
                     fill_escape_char(esc_count - 3, (char)(0x80 | ((utf1 & 0x3F))));
+                    esc_count -= 4;
                 }
             }
 


### PR DESCRIPTION
json中如果中文以\u方式存在，反序列化后会中文无法显示