### PR TITLE
fix \include\iguana\json.hpp(119,13): error C3861: 'render_array': id…

### DIFF
--- a/iguana/json.hpp
+++ b/iguana/json.hpp
@@ -113,12 +113,6 @@ namespace iguana { namespace json
             render_json_value(ss, (std::underlying_type_t<T>&)val);
         }
 
-        template <typename Stream, typename T, size_t N>
-        void render_json_value(Stream& ss, const T(&v)[N])
-        {
-            render_array(ss, v);
-        }
-
         template<typename Stream, typename T>
         void render_array(Stream& ss, const T& v)
         {
@@ -129,6 +123,14 @@ namespace iguana { namespace json
                  });
             ss.put(']');
         }
+
+        template <typename Stream, typename T, size_t N>
+        void render_json_value(Stream& ss, const T(&v)[N])
+        {
+            render_array(ss, v);
+        }
+
+        
 
         template <typename Stream, typename T, size_t N>
         void render_json_value(Stream& ss, const std::array<T, N>& v)

--- a/iguana/json.hpp
+++ b/iguana/json.hpp
@@ -1163,7 +1163,7 @@ namespace iguana { namespace json
 
         template<typename T, typename = std::enable_if_t<is_reflection<T>::value>>
         inline void read_json(reader_t &rd, T &val) {
-            do_read(rd, val);
+            do_read0(rd, val);
             rd.next();
         }
 


### PR DESCRIPTION
 error C3861: 'render_array': identifier not found

visual studio 2019 17.0.5