### PR TITLE
Fix empty struct1

### DIFF
--- a/iguana/json_reader.hpp
+++ b/iguana/json_reader.hpp
@@ -512,20 +512,22 @@ IGUANA_INLINE void from_json(T &value, It &&it, It &&end) {
       match<':'>(it, end);
 
       static constexpr auto frozen_map = get_iguana_struct_map<T>();
-      const auto &member_it = frozen_map.find(key);
-      if (member_it != frozen_map.end()) {
-        std::visit(
-            [&](auto &&member_ptr) IGUANA__INLINE_LAMBDA {
-              using V = std::decay_t<decltype(member_ptr)>;
-              if constexpr (std::is_member_pointer_v<V>) {
-                detail::parse_item(value.*member_ptr, it, end);
-              } else {
-                static_assert(!sizeof(V), "type not supported");
-              }
-            },
-            member_it->second);
-      } else [[unlikely]] {
-        throw std::runtime_error("Unknown key: " + std::string(key));
+      if constexpr (frozen_map.size() > 0) {
+        const auto &member_it = frozen_map.find(key);
+        if (member_it != frozen_map.end()) {
+          std::visit(
+              [&](auto &&member_ptr) IGUANA__INLINE_LAMBDA {
+                using V = std::decay_t<decltype(member_ptr)>;
+                if constexpr (std::is_member_pointer_v<V>) {
+                  detail::parse_item(value.*member_ptr, it, end);
+                } else {
+                  static_assert(!sizeof(V), "type not supported");
+                }
+              },
+              member_it->second);
+        } else [[unlikely]] {
+          throw std::runtime_error("Unknown key: " + std::string(key));
+        }
       }
     }
     skip_ws(it, end);

--- a/test/unit_test.cpp
+++ b/test/unit_test.cpp
@@ -423,7 +423,7 @@ TEST_CASE("test optional") {
 struct empty_t {};
 REFLECTION_EMPTY(empty_t);
 
-TEST_CASE("test canada.json") {
+TEST_CASE("test empty struct") {
   empty_t t;
   std::string str;
   iguana::to_json(t, str);

--- a/test/unit_test.cpp
+++ b/test/unit_test.cpp
@@ -420,6 +420,18 @@ TEST_CASE("test optional") {
   }
 }
 
+struct empty_t {};
+REFLECTION_EMPTY(empty_t);
+
+TEST_CASE("test canada.json") {
+  empty_t t;
+  std::string str;
+  iguana::to_json(t, str);
+  std::cout << str << "\n";
+
+  iguana::from_json(t, str);
+}
+
 TEST_CASE("test unknown fields") {
   std::string str = R"({"dummy":0, "name":"tom", "age":20})";
   person p;


### PR DESCRIPTION
```c++
struct empty_t {};
REFLECTION_EMPTY(empty_t);

TEST_CASE("test empty struct") {
  empty_t t;
  std::string str;
  iguana::to_json(t, str);
  std::cout << str << "\n";

  iguana::from_json(t, str);
}
```