### PR TITLE
fix for keyword

### DIFF
--- a/iguana/reflection.hpp
+++ b/iguana/reflection.hpp
@@ -603,13 +603,22 @@ template <typename... Args> inline auto get_value_type(std::tuple<Args...>) {
   return std::variant<Args...>{};
 }
 
+inline constexpr frozen::string filter_str(const frozen::string &str) {
+  if (str.size() > 2 && str[0] == '_' && str[1] == '_') {
+    auto ptr = str.data() + 2;
+    return frozen::string(ptr, str.size() - 2);
+  }
+  return str;
+}
+
 template <typename T, size_t... Is>
 inline constexpr auto
 get_iguana_struct_map_impl(const std::array<frozen::string, sizeof...(Is)> &arr,
                            T &&t, std::index_sequence<Is...>) {
   using ValueType = decltype(get_value_type(t));
   return frozen::unordered_map<frozen::string, ValueType, sizeof...(Is)>{
-      {arr[Is], ValueType{std::in_place_index<Is>, std::get<Is>(t)}}...};
+      {filter_str(arr[Is]),
+       ValueType{std::in_place_index<Is>, std::get<Is>(t)}}...};
 }
 } // namespace iguana::detail
 

--- a/test/unit_test.cpp
+++ b/test/unit_test.cpp
@@ -432,6 +432,25 @@ TEST_CASE("test empty struct") {
   iguana::from_json(t, str);
 }
 
+struct keyword_t {
+  std::string __private;
+  std::string __public;
+  std::string __protected;
+  std::string __class;
+};
+REFLECTION(keyword_t, __private, __protected, __public, __class);
+
+TEST_CASE("test keyword") {
+  std::string ss =
+      R"({"private":"private","protected":"protected","public":"public","class":"class"})";
+  keyword_t t2;
+  iguana::from_json(t2, ss);
+  CHECK(t2.__private == "private");
+  CHECK(t2.__protected == "protected");
+  CHECK(t2.__public == "public");
+  CHECK(t2.__class == "class");
+}
+
 TEST_CASE("test unknown fields") {
   std::string str = R"({"dummy":0, "name":"tom", "age":20})";
   person p;


### PR DESCRIPTION
```c++
struct keyword_t {
  std::string __private;
  std::string __public;
  std::string __protected;
  std::string __class;
};
REFLECTION(keyword_t, __private, __protected, __public, __class);
```

iguana will remove the prefix "__", so make sure "__" only used for c++ keyword.