### PR TITLE
fix parse & add testcase

### DIFF
--- a/iguana/json_reader.hpp
+++ b/iguana/json_reader.hpp
@@ -627,8 +627,10 @@ template <typename It>
 inline void parse_array(jarray &result, It &&it, It &&end) {
   skip_ws(it, end);
   match<'['>(it, end);
-  if (*it == ']')
+  if (*it == ']') [[unlikely]] {
+    ++it;
     return;
+  }
   while (true) {
     if (it == end) {
       break;
@@ -637,20 +639,22 @@ inline void parse_array(jarray &result, It &&it, It &&end) {
 
     parse(result.back(), it, end);
 
-    if (*it == ']') {
+    if (*it == ']') [[unlikely]] {
       ++it;
       return;
     }
 
     match<','>(it, end);
   }
+  throw std::runtime_error("Expected ]");
 }
 
 template <typename It>
 inline void parse_object(jobject &result, It &&it, It &&end) {
   skip_ws(it, end);
   match<'{'>(it, end);
-  if (*it == '}') {
+  if (*it == '}') [[unlikely]] {
+    ++it;
     return;
   }
 
@@ -671,7 +675,7 @@ inline void parse_object(jobject &result, It &&it, It &&end) {
 
     parse(emplaced.first->second, it, end);
 
-    if (*it == '}') {
+    if (*it == '}') [[unlikely]] {
       ++it;
       return;
     }

--- a/iguana/json_reader.hpp
+++ b/iguana/json_reader.hpp
@@ -464,7 +464,7 @@ IGUANA_INLINE void parse_item(U &value, It &&it, It &&end) {
   match<'"'>(it, end);
 }
 
-inline void skip_object_value(auto &&it, auto &&end) {
+IGUANA_INLINE void skip_object_value(auto &&it, auto &&end) {
   skip_ws(it, end);
   while (it != end) {
     switch (*it) {
@@ -624,7 +624,7 @@ IGUANA_INLINE void from_json(T &value, const Byte *data, size_t size,
 template <typename It> void parse(jvalue &result, It &&it, It &&end);
 
 template <typename It>
-inline void parse_array(jarray &result, It &&it, It &&end) {
+IGUANA_INLINE void parse_array(jarray &result, It &&it, It &&end) {
   skip_ws(it, end);
   match<'['>(it, end);
   if (*it == ']') [[unlikely]] {
@@ -650,7 +650,7 @@ inline void parse_array(jarray &result, It &&it, It &&end) {
 }
 
 template <typename It>
-inline void parse_object(jobject &result, It &&it, It &&end) {
+IGUANA_INLINE void parse_object(jobject &result, It &&it, It &&end) {
   skip_ws(it, end);
   match<'{'>(it, end);
   if (*it == '}') [[unlikely]] {
@@ -684,7 +684,8 @@ inline void parse_object(jobject &result, It &&it, It &&end) {
   }
 }
 
-template <typename It> inline void parse(jvalue &result, It &&it, It &&end) {
+template <typename It>
+IGUANA_INLINE void parse(jvalue &result, It &&it, It &&end) {
   skip_ws(it, end);
   switch (*it) {
   case 'n':
@@ -736,12 +737,29 @@ template <typename It> inline void parse(jvalue &result, It &&it, It &&end) {
 }
 
 template <typename It>
-inline void parse(jvalue &result, It &&it, It &&end, std::error_code &ec) {
+IGUANA_INLINE void parse(jvalue &result, It &&it, It &&end,
+                         std::error_code &ec) {
   try {
     parse(result, it, end);
     ec = {};
   } catch (const std::runtime_error &e) {
     result.template emplace<std::nullptr_t>();
+    ec = iguana::make_error_code(e.what());
+  }
+}
+
+template <typename T, json_view View>
+IGUANA_INLINE void parse(T &result, const View &view) {
+  parse(result, std::begin(view), std::end(view));
+}
+
+template <typename T, json_view View>
+IGUANA_INLINE void parse(T &result, const View &view,
+                         std::error_code &ec) noexcept {
+  try {
+    parse(result, view);
+    ec = {};
+  } catch (std::runtime_error &e) {
     ec = iguana::make_error_code(e.what());
   }
 }

--- a/iguana/value.hpp
+++ b/iguana/value.hpp
@@ -6,6 +6,8 @@
 #include <variant>
 #include <vector>
 
+#include "error_code.h"
+
 namespace iguana {
 
 #define GCC_COMPILER (defined(__GNUC__) && !defined(__clang__))

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -227,11 +227,16 @@ TEST_CASE("test dom parse") {
     CHECK(val1.is_object());
     CHECK(val1.to_object().size() == 1);
   }
+  {
+    std::string json_str = R"({ "b": [{}, {"c":1}] })";
+    iguana::jvalue val;
+    CHECK_NOTHROW(iguana::parse(val, json_str.begin(), json_str.end()));
+  }
 
   std::cout << "test dom parse part 2 ok\n";
 
   {
-    std::string json_str = R"([0.5, 2.2, 3.3, 4])";
+    std::string json_str = R"([0.5, 2.2, 3.3, 4, "6.7"])";
     iguana::jvalue val1;
     iguana::parse(val1, json_str.begin(), json_str.end());
     auto &arr = std::get<iguana::jarray>(val1);
@@ -253,10 +258,12 @@ TEST_CASE("test dom parse") {
     CHECK(std::get<double>(arr[0]) == 0.5);
     CHECK(std::get<double>(arr[1]) == 2.2);
     CHECK(std::get<double>(arr[2]) == 3.3);
+    // could arr elems be different type?
+    CHECK(std::get<std::string>(arr[4]) == "6.7");
 
     CHECK(val1.is_array());
     const iguana::jarray &arr1 = val1.to_array();
-    CHECK(arr1.size() == 4);
+    CHECK(arr1.size() == 5);
     CHECK(arr1[0].to_double() == 0.5);
     CHECK(arr1[3].is_int());
 
@@ -631,7 +638,6 @@ TEST_CASE("test file interface") {
   {
     fs::path p = "empty_file.bin";
     std::ofstream{p};
-    std::cout << p << " size = " << fs::file_size(p) << '\n';
     test_empty_t empty_obj;
     CHECK_THROWS_WITH(iguana::from_json_file(empty_obj, p.string()),
                       "empty file");


### PR DESCRIPTION
1. [fix] parse array contains empty object throw Expect:, or contains empty array.
2. parse support View as para
3. add testcase for dom parse file