### PR TITLE
support attribute variant

### DIFF
--- a/example/xml_example.cpp
+++ b/example/xml_example.cpp
@@ -249,6 +249,37 @@ void test_nested_attribute() {
   std::cout << std::endl;
   std::cout << "\nbook\n" << library.book;
 }
+struct movie_t {
+  std::string title;
+  std::string director;
+  std::unordered_map<std::string, std::variant<std::string, int, float>> __attr;
+};
+REFLECTION(movie_t, title, director, __attr);
+void test_variant_attribute() {
+  std::cout << "********** test attribute with variant ************"
+            << std::endl;
+  std::string str = R"(
+  <movie id="1" time="2.3" price="32.8" language="en">
+    <title>Harry Potter and the Philosopher's Stone</title>
+    <director>Chris Columbus</director>
+  </movie>
+)";
+  movie_t movie;
+  iguana::xml::from_xml(movie, str.data());
+  std::cout << "movie attribute :" << std::endl;
+  for (auto &[key, value] : movie.__attr) {
+    std::string_view str = key.data();
+    std::visit(
+        [str](auto &&attr_value) {
+          if (str != "language")
+            assert(typeid(attr_value) == typeid(float));
+          std::cout << "[ " << str << " : " << attr_value << "]"
+                    << typeid(attr_value).name() << " ";
+        },
+        value);
+  }
+  std::cout << std::endl;
+}
 
 int main(void) {
   test_parse_response();
@@ -259,6 +290,7 @@ int main(void) {
   test_optional();
   test_attribute();
   test_nested_attribute();
+  test_variant_attribute();
 
   return 0;
 }

--- a/example/xml_example.cpp
+++ b/example/xml_example.cpp
@@ -252,12 +252,11 @@ void test_nested_attribute() {
 struct movie_t {
   std::string title;
   std::string director;
-  std::unordered_map<std::string, std::variant<std::string, int, float>> __attr;
+  std::unordered_map<std::string, iguana::xml::any_t> __attr;
 };
 REFLECTION(movie_t, title, director, __attr);
-void test_variant_attribute() {
-  std::cout << "********** test attribute with variant ************"
-            << std::endl;
+void test_any_attribute() {
+  std::cout << "********** test attribute with any ************" << std::endl;
   std::string str = R"(
   <movie id="1" time="2.3" price="32.8" language="en">
     <title>Harry Potter and the Philosopher's Stone</title>
@@ -267,16 +266,27 @@ void test_variant_attribute() {
   movie_t movie;
   iguana::xml::from_xml(movie, str.data());
   std::cout << "movie attribute :" << std::endl;
-  for (auto &[key, value] : movie.__attr) {
-    std::string_view str = key.data();
-    std::visit(
-        [str](auto &&attr_value) {
-          if (str != "language")
-            assert(typeid(attr_value) == typeid(float));
-          std::cout << "[ " << str << " : " << attr_value << "]"
-                    << typeid(attr_value).name() << " ";
-        },
-        value);
+  auto &attr = movie.__attr;
+  {
+    auto [isok, value] = attr["id"].get<int>();
+    assert(isok == true);
+    std::cout << "[ "
+              << "id"
+              << " : " << value << "]";
+  }
+  {
+    auto [isok, value] = attr["price"].get<float>();
+    assert(isok == true);
+    std::cout << "[ "
+              << "id"
+              << " : " << value << "]";
+  }
+  {
+    auto [isok, value] = attr["language"].get<std::string>();
+    assert(isok == true);
+    std::cout << "[ "
+              << "language"
+              << " : " << value << "]";
   }
   std::cout << std::endl;
 }
@@ -290,7 +300,7 @@ int main(void) {
   test_optional();
   test_attribute();
   test_nested_attribute();
-  test_variant_attribute();
+  test_any_attribute();
 
   return 0;
 }

--- a/iguana/type_traits.hpp
+++ b/iguana/type_traits.hpp
@@ -21,6 +21,4 @@ template <typename T> constexpr inline bool is_std_optinal_v = false;
 template <typename T>
 constexpr inline bool is_std_optinal_v<std::optional<T>> = true;
 
-template <typename T> constexpr inline bool is_std_variant_v = false;
-
 } // namespace iguana

--- a/iguana/type_traits.hpp
+++ b/iguana/type_traits.hpp
@@ -16,4 +16,36 @@ struct is_map_container<
     T, std::void_t<decltype(std::declval<typename T::mapped_type>())>>
     : public is_container<T> {};
 
+template <typename T> constexpr inline bool is_std_optinal_v = false;
+
+template <typename T>
+constexpr inline bool is_std_optinal_v<std::optional<T>> = true;
+
+template <typename T> constexpr inline bool is_std_variant_v = false;
+
+template <typename... Args>
+constexpr inline bool is_std_variant_v<std::variant<Args...>> = true;
+
+template <typename T, typename C>
+struct is_variant_contains_type : std::false_type {};
+
+template <typename T, typename... Args>
+struct is_variant_contains_type<T, std::variant<Args...>>
+    : std::bool_constant<(std::is_same_v<T, std::remove_cvref_t<Args>> ||
+                          ...)> {};
+
+template <typename... Args> struct variant_first_match;
+
+template <typename C, typename T> struct variant_first_match<C, T> {
+  using type =
+      std::conditional_t<is_variant_contains_type<T, C>::value, T, void>;
+};
+
+template <typename C, typename T, typename... Args>
+struct variant_first_match<C, T, Args...> {
+  using type =
+      std::conditional_t<is_variant_contains_type<T, C>::value, T,
+                         typename variant_first_match<C, Args...>::type>;
+};
+
 } // namespace iguana

--- a/iguana/type_traits.hpp
+++ b/iguana/type_traits.hpp
@@ -23,29 +23,4 @@ constexpr inline bool is_std_optinal_v<std::optional<T>> = true;
 
 template <typename T> constexpr inline bool is_std_variant_v = false;
 
-template <typename... Args>
-constexpr inline bool is_std_variant_v<std::variant<Args...>> = true;
-
-template <typename T, typename C>
-struct is_variant_contains_type : std::false_type {};
-
-template <typename T, typename... Args>
-struct is_variant_contains_type<T, std::variant<Args...>>
-    : std::bool_constant<(std::is_same_v<T, std::remove_cvref_t<Args>> ||
-                          ...)> {};
-
-template <typename... Args> struct variant_first_match;
-
-template <typename C, typename T> struct variant_first_match<C, T> {
-  using type =
-      std::conditional_t<is_variant_contains_type<T, C>::value, T, void>;
-};
-
-template <typename C, typename T, typename... Args>
-struct variant_first_match<C, T, Args...> {
-  using type =
-      std::conditional_t<is_variant_contains_type<T, C>::value, T,
-                         typename variant_first_match<C, Args...>::type>;
-};
-
 } // namespace iguana

--- a/iguana/xml_reader.hpp
+++ b/iguana/xml_reader.hpp
@@ -19,8 +19,9 @@ public:
   explicit any_t(std::string_view value) : value_(value) {}
   explicit any_t() {}
   template <typename T> std::pair<bool, T> get() const {
-    if constexpr (std::is_same_v<T, std::string>) {
-      return std::make_pair(true, std::string(value_));
+    if constexpr (std::is_same_v<T, std::string> ||
+                  std::is_same_v<T, std::string_view>) {
+      return std::make_pair(true, T{value_});
     } else if constexpr (std::is_arithmetic_v<T>) {
       double num;
       auto [p, ec] = fast_float::from_chars(value_.data(),

--- a/iguana/xml_reader.hpp
+++ b/iguana/xml_reader.hpp
@@ -32,10 +32,6 @@ public:
       static_assert(!sizeof(T), "don't support this type!!");
     }
   }
-  any_t &operator=(const std::string_view str) {
-    value_ = str;
-    return *this;
-  }
 
 private:
   std::string_view value_;
@@ -94,7 +90,7 @@ inline void parse_attribute(rapidxml::xml_node<char> *node, T &t) {
     std::string_view value = attr->value();
     if constexpr (std::is_same_v<std::string, value_type> ||
                   std::is_same_v<any_t, value_type>) {
-      value_item = attr->value();
+      value_item = value_type{attr->value()};
     } else if constexpr (std::is_arithmetic_v<value_type> &&
                          !std::is_same_v<bool, value_type>) {
       double num;


### PR DESCRIPTION
first of all, I make some traits:
1. move the _is_std_optinal_v_ to type_traits.hpp
2. add _is_std_variant_v_ 
3. add _is_variant_contains_type_ similar to the  _std::holds_alternative_
4. add _variant_first_match_ to match the first type in the variant

secondly, I match the type in variant  using  _variant_first_match_  as shown below:
![image](https://user-images.githubusercontent.com/68217560/235315212-08f17d2c-d3dd-4613-af5b-38cc0842e3ab.png)
And if there is a numeric type, always try to parse the value to a numeric type first. when parsing fails,  if there is a std::string type, it will parse to a std::string type, otherwise an error will be thrown

Finally,  it passes the assert in test_variant_attribute 