### PR TITLE
support attribute to_xml and add unittest

### DIFF
--- a/example/xml_example.cpp
+++ b/example/xml_example.cpp
@@ -225,7 +225,11 @@ void test_attribute() {
   book_t book{};
   iguana::xml::from_xml(book, str.data());
   std::cout << book;
+  std::string ss;
+  iguana::xml::to_xml(ss, book);
+  std::cout << "attr to_xml: " << ss << std::endl;
 }
+
 struct library_t {
   book_t book;
   std::unordered_map<std::string, std::string> __attr;
@@ -251,6 +255,10 @@ void test_nested_attribute() {
   }
   std::cout << std::endl;
   std::cout << "\nbook\n" << library.book;
+
+  std::string ss;
+  iguana::xml::to_xml(ss, library);
+  std::cout << "library to_xml: " << ss << std::endl;
 }
 struct movie_t {
   std::string title;

--- a/iguana/xml_reader.hpp
+++ b/iguana/xml_reader.hpp
@@ -53,6 +53,8 @@ public:
     }
   }
 
+  const std::string_view get_value() const { return value_; }
+
 private:
   std::string_view value_;
 };

--- a/iguana/xml_writer.hpp
+++ b/iguana/xml_writer.hpp
@@ -14,21 +14,6 @@
 #include <string.h>
 
 namespace iguana::xml {
-
-template <typename T, typename C, size_t Is = 0>
-constexpr inline size_t get_variant_map_index() {
-  if constexpr (Is < std::variant_size_v<T>) {
-    using M = std::variant_alternative_t<Is, T>;
-    using V = std::decay_t<decltype(std::declval<C>().*std::declval<M>())>;
-    if constexpr (is_map_container<V>::value) {
-      return Is;
-    } else {
-      return get_variant_map_index<T, C, Is + 1>();
-    }
-  } else {
-    return std::variant_size_v<T>;
-  }
-}
 // to xml
 template <typename Stream, typename T>
 inline void to_xml_impl(Stream &s, T &&t, std::string_view name = "");
@@ -119,8 +104,8 @@ inline void to_xml_impl(Stream &s, T &&t, std::string_view name) {
   using MapValueType = std::remove_cvref_t<
       typename decltype(get_iguana_struct_map<T>())::mapped_type>;
   constexpr auto Idx =
-      get_variant_map_index<MapValueType, std::remove_cvref_t<T>>();
-  if constexpr (Idx != std::variant_size_v<MapValueType>) { // has map
+      get_type_index<is_map_container, std::remove_cvref_t<T>>();
+  if constexpr (Idx != std::variant_size_v<MapValueType>) {
     auto attr_value = get<Idx>(t);
     for (auto &[k, v] : attr_value) {
       s.append(" ").append(k).append("=\"");

--- a/iguana/xml_writer.hpp
+++ b/iguana/xml_writer.hpp
@@ -73,6 +73,11 @@ inline void render_xml_value(Stream &ss, const std::optional<T> &s) {
   }
 }
 
+template <typename Stream>
+inline void render_xml_value(Stream &ss, const any_t &t) {
+  ss.append(t.get_value().data(), t.get_value().size());
+}
+
 template <typename Stream> inline void render_tail(Stream &ss, const char *s) {
   ss.push_back('<');
   ss.push_back('/');

--- a/test/test_xml.cpp
+++ b/test/test_xml.cpp
@@ -205,6 +205,14 @@ TEST_CASE("test attribute with map") {
   CHECK(b.__attr["id"] == 5);
   CHECK(b.__attr["pages"] == 392.0f);
   CHECK(b.__attr["price"] == 79.9f);
+
+  std::string ss;
+  iguana::xml::to_xml_pretty(ss, b);
+  book_attr_t b2;
+  iguana::xml::from_xml(b2, ss.data());
+  CHECK(b2.__attr["id"] == 5);
+  CHECK(b2.__attr["pages"] == 392.0f);
+  CHECK(b2.__attr["price"] == 79.9f);
 }
 
 struct book_attr_any_t {
@@ -221,6 +229,18 @@ TEST_CASE("test attribute with any") {
   book_attr_any_t b;
   iguana::xml::from_xml(b, str.data());
   auto &map = b.__attr;
+  CHECK(map["id"].get<int>().first);
+  CHECK(map["id"].get<int>().second == 5);
+  CHECK(map["language"].get<std::string_view>().first);
+  CHECK(map["language"].get<std::string_view>().second == "en");
+  CHECK(map["price"].get<float>().first);
+  CHECK(map["price"].get<float>().second == 79.9f);
+
+  std::string ss;
+  iguana::xml::to_xml(ss, b);
+  book_attr_any_t b1;
+  iguana::xml::from_xml(b1, ss.data());
+  map = b1.__attr;
   CHECK(map["id"].get<int>().first);
   CHECK(map["id"].get<int>().second == 5);
   CHECK(map["language"].get<std::string_view>().first);
@@ -245,7 +265,7 @@ TEST_CASE("Test nested attribute with any") {
   library_attr_t library;
   iguana::xml::from_xml(library, str.data());
 
-  auto &map = library.__attr;
+  auto map = library.__attr;
   CHECK(map["code"].get<int>().first);
   CHECK(map["code"].get<int>().second == 102);
   CHECK(map["name"].get<std::string>().second == "UESTC");
@@ -254,6 +274,27 @@ TEST_CASE("Test nested attribute with any") {
   CHECK(map["time"].get<float>().second == 3.2f);
 
   map = library.book.__attr;
+  CHECK(map["id"].get<int>().first);
+  CHECK(map["id"].get<int>().second == 5);
+  CHECK(map["language"].get<std::string_view>().first);
+  CHECK(map["language"].get<std::string_view>().second == "en");
+  CHECK(map["price"].get<float>().first);
+  CHECK(map["price"].get<float>().second == 79.9f);
+
+  std::string ss;
+  iguana::xml::to_xml_pretty(ss, library);
+  std::cout << ss << std::endl;
+  library_attr_t library1;
+  iguana::xml::from_xml(library1, ss.data());
+  map = library1.__attr;
+  CHECK(map["code"].get<int>().first);
+  CHECK(map["code"].get<int>().second == 102);
+  CHECK(map["name"].get<std::string>().second == "UESTC");
+  CHECK(map["name"].get<std::string_view>().second == "UESTC");
+  CHECK(map["time"].get<float>().first);
+  CHECK(map["time"].get<float>().second == 3.2f);
+
+  map = library1.book.__attr;
   CHECK(map["id"].get<int>().first);
   CHECK(map["id"].get<int>().second == 5);
   CHECK(map["language"].get<std::string_view>().first);

--- a/test/test_xml.cpp
+++ b/test/test_xml.cpp
@@ -301,6 +301,20 @@ TEST_CASE("Test nested attribute with any") {
   CHECK(map["language"].get<std::string_view>().second == "en");
   CHECK(map["price"].get<float>().first);
   CHECK(map["price"].get<float>().second == 79.9f);
+  CHECK_FALSE(map["language"].get<int>().first); // parse num failed
+}
+
+TEST_CASE("test exception") {
+  simple_t simple;
+  std::string str = R"(
+    <simple_t><a>1</a><a>2</a><a>3</a><b>|</b><c>False</c><d>True</d><e></e></
+  )";
+  CHECK_FALSE(iguana::xml::from_xml(simple, str.data())); // expected >
+  std::string str2 = R"(
+    <simple_t><a>1</a><a>2</a><a>3</a><b>|</b><c>Flase</c><d>tru</d><e></e></simple_t>
+  )";
+  CHECK_NOTHROW(
+      iguana::xml::from_xml(simple, str2.data())); // Failed to parse bool
 }
 
 // doctest comments


### PR DESCRIPTION
To do this, I added a compile time  function get_ variant_ map_ Index to retrieves the index of the **map** type in the variant. 