### PR TITLE
support std::string_view as json::value

### DIFF
--- a/example/json_example.cpp
+++ b/example/json_example.cpp
@@ -113,6 +113,31 @@ void test_disorder() {
   iguana::from_json(s1, str2.data(), str2.length());
 }
 
+struct book_t {
+  std::string_view title;
+  std::string_view edition;
+  std::vector<std::string_view> author;
+};
+REFLECTION(book_t, title, edition, author);
+
+void test_str_view() {
+  {
+    std::string str = R"({
+    "title": "C++ templates",
+    "edition": "invalid number",
+    "author": [
+      "David Vandevoorde",
+      "Nicolai M. Josuttis"
+    ]})";
+    book_t b;
+    iguana::from_json(b, str);
+    std::cout << b.title << std::endl;
+    std::cout << b.edition << std::endl;
+    std::cout << b.author[0] << std::endl;
+    std::cout << b.author[1] << std::endl;
+  }
+}
+
 int main(void) {
   test_disorder();
   test_v();
@@ -127,6 +152,7 @@ int main(void) {
   iguana::from_json(p2, ss.data(), ss.length());
 
   std::cout << p2.name << " - " << p2.age << std::endl;
+  test_str_view();
 
   return 0;
 }

--- a/iguana/json_reader.hpp
+++ b/iguana/json_reader.hpp
@@ -347,6 +347,7 @@ IGUANA_INLINE void parse_item(U &value, It &&it, It &&end) {
 template <map_container U, class It>
 IGUANA_INLINE void parse_item(U &value, It &&it, It &&end) {
   using T = std::remove_reference_t<U>;
+  using key_type = typename T::key_type;
   skip_ws(it, end);
 
   match<'{'>(it, end);
@@ -362,16 +363,16 @@ IGUANA_INLINE void parse_item(U &value, It &&it, It &&end) {
       match<','>(it, end);
     }
 
-    static thread_local std::string key{};
+    static thread_local std::string_view key{};
     parse_item(key, it, end);
 
     skip_ws(it, end);
     match<':'>(it, end);
 
-    if constexpr (std::is_same_v<typename T::key_type, std::string>) {
-      parse_item(value[key], it, end);
+    if constexpr (str_t<key_type> || str_view_t<key_type>) {
+      parse_item(value[key_type(key)], it, end);
     } else {
-      static thread_local typename T::key_type key_value{};
+      static thread_local key_type key_value{};
       parse_item(key_value, key.begin(), key.end());
       parse_item(value[key_value], it, end);
     }

--- a/iguana/value.hpp
+++ b/iguana/value.hpp
@@ -25,23 +25,26 @@ enum dom_parse_error { ok, wrong_type };
 
 template <typename CharT>
 struct basic_json_value
-    : std::variant<
-          std::monostate, std::nullptr_t, bool, double, int,
-          std::basic_string<CharT>, std::vector<basic_json_value<CharT>>,
-          json_map<std::basic_string<CharT>, basic_json_value<CharT>>> {
+    : std::variant<std::monostate, std::nullptr_t, bool, double, int,
+                   std::basic_string<CharT>,
+                   std::vector<basic_json_value<CharT>>,
+                   json_map<std::basic_string<CharT>, basic_json_value<CharT>>,
+                   std::basic_string_view<CharT>> {
   using string_type = std::basic_string<CharT>;
+  using string_view_type = std::basic_string_view<CharT>;
   using array_type = std::vector<basic_json_value<CharT>>;
   using object_type = json_map<string_type, basic_json_value<CharT>>;
 
-  using base_type = std::variant<std::monostate, std::nullptr_t, bool, double,
-                                 int, string_type, array_type, object_type>;
+  using base_type =
+      std::variant<std::monostate, std::nullptr_t, bool, double, int,
+                   string_type, array_type, object_type, string_view_type>;
 
   using base_type::base_type;
 
   inline const static std::unordered_map<size_t, std::string> type_map_ = {
-      {0, "undefined type"}, {1, "null type"},  {2, "bool type"},
-      {3, "double type"},    {4, "int type"},   {5, "string type"},
-      {6, "array type"},     {7, "object type"}};
+      {0, "undefined type"}, {1, "null type"},   {2, "bool type"},
+      {3, "double type"},    {4, "int type"},    {5, "string type"},
+      {6, "array type"},     {7, "object type"}, {8, "string_view type"}};
 
   basic_json_value() : base_type(std::in_place_type<std::monostate>) {}
 
@@ -62,6 +65,9 @@ struct basic_json_value
   bool is_string() const { return std::holds_alternative<string_type>(*this); }
   bool is_array() const { return std::holds_alternative<array_type>(*this); }
   bool is_object() const { return std::holds_alternative<object_type>(*this); }
+  bool is_string_view() const {
+    return std::holds_alternative<string_view_type>(*this);
+  }
 
   // if type is not match, will throw exception, if pass std::error_code, won't
   // throw exception
@@ -94,7 +100,6 @@ struct basic_json_value
     v = get<T>(ec);
     return ec;
   }
-
   template <typename T> T at(const std::string &key) {
     const auto &map = get<object_type>();
     auto it = map.find(key);
@@ -157,11 +162,14 @@ struct basic_json_value
   bool to_bool() const { return get<bool>(); }
   bool to_bool(std::error_code &ec) const { return get<bool>(ec); }
 
-  std::basic_string<CharT> to_string() const {
-    return get<std::basic_string<CharT>>();
+  string_type to_string() const { return get<string_type>(); }
+  string_type to_string(std::error_code &ec) const {
+    return get<string_type>(ec);
   }
-  std::basic_string<CharT> to_string(std::error_code &ec) const {
-    return get<std::basic_string<CharT>>(ec);
+
+  string_view_type to_string_view() const { return get<string_view_type>(); }
+  string_view_type to_string_view(std::error_code &ec) const {
+    return get<string_view_type>(ec);
   }
 };
 

--- a/test/unit_test.cpp
+++ b/test/unit_test.cpp
@@ -597,6 +597,45 @@ TEST_CASE("test from_json_file") {
   std::filesystem::remove("dummy_test_dir.json");
 }
 
+struct book_t {
+  std::string_view title;
+  std::optional<std::string_view> edition;
+  std::vector<std::string_view> author;
+};
+REFLECTION(book_t, title, edition, author);
+TEST_CASE("test the string_view") {
+  {
+    std::string str = R"("C++ \ntemplates")";
+    std::string_view t;
+    iguana::from_json(t, str);
+    CHECK(t == R"(C++ \ntemplates)");
+  }
+  {
+    std::string str = R"({
+      "title": "C++ templates",
+      "edition": "invalid number"})";
+    book_t b;
+    iguana::from_json(b, str);
+    CHECK(b.title == "C++ templates");
+    CHECK(*(b.edition) == "invalid number");
+  }
+  {
+    std::string str = R"({
+    "title": "C++ templates",
+    "edition": "invalid number",
+    "author": [
+      "David Vandevoorde",
+      "Nicolai M. Josuttis"
+    ]})";
+    book_t b;
+    iguana::from_json(b, str);
+    CHECK(b.title == "C++ templates");
+    CHECK(*(b.edition) == "invalid number");
+    CHECK(b.author[0] == "David Vandevoorde");
+    CHECK(b.author[1] == "Nicolai M. Josuttis");
+  }
+}
+
 // doctest comments
 // 'function' : must be 'attribute' - see issue #182
 DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4007) int main(int argc, char **argv) {

--- a/test/unit_test.cpp
+++ b/test/unit_test.cpp
@@ -634,6 +634,28 @@ TEST_CASE("test the string_view") {
     CHECK(b.author[0] == "David Vandevoorde");
     CHECK(b.author[1] == "Nicolai M. Josuttis");
   }
+  {
+    std::string str = R"(["tom", 30, 25.8])";
+    std::tuple<std::string_view, int, float> t;
+    iguana::from_json(t, str);
+    CHECK(std::get<0>(t) == "tom");
+    CHECK(std::get<1>(t) == 30);
+    CHECK(std::get<2>(t) == 25.8f);
+  }
+  {
+    std::string str = R"(["tom", "jone"])";
+    std::string_view arr[2];
+    iguana::from_json(arr, str);
+    CHECK(arr[0] == "tom");
+    CHECK(arr[1] == "jone");
+  }
+  {
+    std::unordered_map<std::string_view, std::string_view> mp;
+    std::string str = R"({"tom" : "C++", "jone" : "Go"})";
+    iguana::from_json(mp, str);
+    CHECK(mp["tom"] == "C++");
+    CHECK(mp["jone"] == "Go");
+  }
 }
 
 // doctest comments


### PR DESCRIPTION
This support the std::string_view to be the json value but except the key and the value of the map type of json value. This is what I will do next