### PR TITLE
support required fields

### DIFF
--- a/iguana/reflection.hpp
+++ b/iguana/reflection.hpp
@@ -623,8 +623,6 @@ get_iguana_struct_map_impl(const std::array<frozen::string, sizeof...(Is)> &arr,
 } // namespace iguana::detail
 
 namespace iguana {
-inline std::unordered_map<std::string_view, std::vector<std::string_view>>
-    g_iguana_required_map;
 inline std::unordered_map<
     std::string_view,
     std::vector<std::pair<std::string_view, std::string_view>>>
@@ -645,24 +643,34 @@ template <typename T> inline constexpr auto get_iguana_struct_map() {
 
 #define REFLECTION_EMPTY(STRUCT_NAME) MAKE_META_DATA_EMPTY(STRUCT_NAME)
 
-inline int add_required(std::string_view key, std::vector<std::string_view> v) {
-  iguana::g_iguana_required_map.emplace(key, v);
-  return 0;
-}
-
 #ifdef _MSC_VER
 #define IGUANA_UNIQUE_VARIABLE(str) MACRO_CONCAT(str, __COUNTER__)
 #else
 #define IGUANA_UNIQUE_VARIABLE(str) MACRO_CONCAT(str, __LINE__)
 #endif
-
+template <typename T> struct iguana_required_struct;
 #define REQUIRED_IMPL(STRUCT_NAME, N, ...)                                     \
-  inline auto IGUANA_UNIQUE_VARIABLE(STRUCT_NAME) = iguana::add_required(      \
-      #STRUCT_NAME, std::vector<std::string_view>{                             \
-                        MARCO_EXPAND(MACRO_CONCAT(CON_STR, N)(__VA_ARGS__))});
+  template <> struct iguana::iguana_required_struct<STRUCT_NAME> {             \
+    inline static constexpr auto requied_arr() {                               \
+      std::array<std::string_view, N> arr_required = {                         \
+          MARCO_EXPAND(MACRO_CONCAT(CON_STR, N)(__VA_ARGS__))};                \
+      return arr_required;                                                     \
+    }                                                                          \
+  };
 
 #define REQUIRED(STRUCT_NAME, ...)                                             \
   REQUIRED_IMPL(STRUCT_NAME, GET_ARG_COUNT(__VA_ARGS__), __VA_ARGS__)
+
+template <class T, class = void>
+struct has_iguana_required_arr : std::false_type {};
+
+template <class T>
+struct has_iguana_required_arr<
+    T, std::void_t<decltype(iguana_required_struct<T>::requied_arr())>>
+    : std::true_type {};
+
+template <class T>
+constexpr bool has_iguana_required_arr_v = has_iguana_required_arr<T>::value;
 
 inline std::string_view trim_sv(std::string_view str) {
   std::string_view whitespaces(" \t\f\v\n\r");
@@ -809,17 +817,6 @@ constexpr std::enable_if_t<!is_reflection<T>::value, size_t> get_value() {
 template <typename T> constexpr auto get_array() {
   using M = decltype(iguana_reflect_members(std::declval<T>()));
   return M::arr();
-}
-
-template <typename T> inline bool is_required(std::string_view key) {
-  constexpr std::string_view name = get_name<T>();
-  auto it = g_iguana_required_map.find(name);
-  if (it == g_iguana_required_map.end())
-    return false;
-
-  auto &v = it->second;
-  auto r = std::find(v.begin(), v.end(), key);
-  return r != v.end();
 }
 
 template <typename T> inline bool has_custom_fields(std::string_view key = "") {

--- a/test/test_xml.cpp
+++ b/test/test_xml.cpp
@@ -432,6 +432,28 @@ TEST_CASE("test get_number") {
   CHECK(iguana::get_number<float>(str) == 3.14f);
 }
 
+struct some_book {
+  std::string_view title;
+  std::string_view author;
+};
+REFLECTION(some_book, title, author);
+REQUIRED(some_book, title, author);
+
+TEST_CASE("test required filed") {
+  some_book book{"book", "tom"};
+  std::string xml_str;
+  iguana::to_xml(book, xml_str);
+
+  std::cout << xml_str << "\n";
+
+  std::string s1 = R"(<book_t><title>book</title></book_t>)";
+  some_book b;
+  CHECK_THROWS_AS(iguana::from_xml(b, s1), std::invalid_argument);
+
+  std::string s2 = R"(<book_t><author>tom</author></book_t>)";
+  CHECK_THROWS_AS(iguana::from_xml(b, s2), std::invalid_argument);
+}
+
 // doctest comments
 // 'function' : must be 'attribute' - see issue #182
 DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4007)


### PR DESCRIPTION
If defined required fields, but the xml string lack of required fileds, iguana will throw exception.

```c++
struct some_book {
  std::string_view title;
  std::string_view author;
};
REFLECTION(some_book, title, author);
REQUIRED(some_book, title, author);

TEST_CASE("test required filed") {
  some_book book{"book", "tom"};
  std::string xml_str;
  iguana::to_xml(book, xml_str);

  std::cout << xml_str << "\n";

  std::string s1 = R"(<book_t><title>book</title></book_t>)";
  some_book b;
  CHECK_THROWS_AS(iguana::from_xml(b, s1), std::invalid_argument);

  std::string s2 = R"(<book_t><author>tom</author></book_t>)";
  CHECK_THROWS_AS(iguana::from_xml(b, s2), std::invalid_argument);
}
```