### PR TITLE
support alias fields

### DIFF
--- a/iguana/reflection.hpp
+++ b/iguana/reflection.hpp
@@ -584,6 +584,40 @@ namespace iguana::detail {
   MAKE_META_DATA_IMPL(STRUCT_NAME,                                             \
                       MAKE_ARG_LIST(N, &STRUCT_NAME::FIELD, __VA_ARGS__))
 
+#define REFLECTION_ALIAS_IMPL(STRUCT_NAME, ALIAS, N, ...)                      \
+  MAKE_META_DATA_IMPL_ALIAS(STRUCT_NAME, ALIAS, __VA_ARGS__)
+
+#define FLDALIAS(a, b)                                                         \
+  std::pair { a, b }
+
+template <typename... Args> constexpr auto get_mem_ptr_tp(Args... pair) {
+  return std::make_tuple(std::get<0>(pair)...);
+}
+
+template <size_t N, typename... Args>
+constexpr std::array<frozen::string, N> get_alias_arr(Args... pairs) {
+  return std::array<frozen::string, sizeof...(Args)>{
+      frozen::string(std::get<1>(pairs))...};
+}
+
+#define MAKE_META_DATA_IMPL_ALIAS(STRUCT_NAME, ALIAS, ...)                     \
+  [[maybe_unused]] inline static auto iguana_reflect_members(                  \
+      STRUCT_NAME const &) {                                                   \
+    struct reflect_members {                                                   \
+      constexpr decltype(auto) static apply_impl() {                           \
+        return iguana::detail::get_mem_ptr_tp(__VA_ARGS__);                    \
+      }                                                                        \
+      using size_type = std::integral_constant<                                \
+          size_t, std::tuple_size_v<decltype(std::make_tuple(__VA_ARGS__))>>;  \
+      constexpr static std::string_view name() { return ALIAS; }               \
+      constexpr static size_t value() { return size_type::value; }             \
+      constexpr static std::array<frozen::string, size_type::value> arr() {    \
+        return iguana::detail::get_alias_arr<size_type::value>(__VA_ARGS__);   \
+      }                                                                        \
+    };                                                                         \
+    return reflect_members{};                                                  \
+  }
+
 #define MAKE_META_DATA_IMPL_EMPTY(STRUCT_NAME)                                 \
   inline auto iguana_reflect_members(STRUCT_NAME const &) {                    \
     struct reflect_members {                                                   \
@@ -656,6 +690,11 @@ template <typename T> inline constexpr auto get_iguana_struct_map() {
                  __VA_ARGS__)
 
 #define REFLECTION_EMPTY(STRUCT_NAME) MAKE_META_DATA_EMPTY(STRUCT_NAME)
+
+#define REFLECTION_ALIAS(STRUCT_NAME, ALIAS, ...)                              \
+  REFLECTION_ALIAS_IMPL(                                                       \
+      STRUCT_NAME, ALIAS,                                                      \
+      std::tuple_size_v<decltype(std::make_tuple(__VA_ARGS__))>, __VA_ARGS__)
 
 #ifdef _MSC_VER
 #define IGUANA_UNIQUE_VARIABLE(str) MACRO_CONCAT(str, __COUNTER__)

--- a/test/test_xml.cpp
+++ b/test/test_xml.cpp
@@ -693,6 +693,32 @@ TEST_CASE("test smart_ptr") {
   validator(cont1);
 }
 
+struct next_obj_t{
+    int x;
+    int y;
+};
+REFLECTION_ALIAS(next_obj_t, "next", FLDALIAS(&next_obj_t::x, "w"), FLDALIAS(&next_obj_t::y, "h"));
+
+struct out_object{
+    std::unique_ptr<int> id;
+    std::string_view name;
+    next_obj_t obj;
+    REFLECTION_ALIAS(out_object, "qi", FLDALIAS(&out_object::id, "i"), FLDALIAS(&out_object::name, "na"), FLDALIAS(&out_object::obj, "obj"));
+};
+
+
+TEST_CASE("test alias") {
+  out_object m{std::make_unique<int>(20), "tom", {21, 42}};
+  std::string xml_str;
+  iguana::to_xml(m, xml_str);
+
+  out_object m1;
+  iguana::from_xml(m1, xml_str);
+  CHECK(m1.name=="tom");
+  CHECK(m1.obj.x == 21);
+  CHECK(m1.obj.y == 42);
+}
+
 // doctest comments
 // 'function' : must be 'attribute' - see issue #182
 DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4007)

--- a/test/test_xml.cpp
+++ b/test/test_xml.cpp
@@ -693,19 +693,21 @@ TEST_CASE("test smart_ptr") {
   validator(cont1);
 }
 
-struct next_obj_t{
-    int x;
-    int y;
+struct next_obj_t {
+  int x;
+  int y;
 };
-REFLECTION_ALIAS(next_obj_t, "next", FLDALIAS(&next_obj_t::x, "w"), FLDALIAS(&next_obj_t::y, "h"));
+REFLECTION_ALIAS(next_obj_t, "next", FLDALIAS(&next_obj_t::x, "w"),
+                 FLDALIAS(&next_obj_t::y, "h"));
 
-struct out_object{
-    std::unique_ptr<int> id;
-    std::string_view name;
-    next_obj_t obj;
-    REFLECTION_ALIAS(out_object, "qi", FLDALIAS(&out_object::id, "i"), FLDALIAS(&out_object::name, "na"), FLDALIAS(&out_object::obj, "obj"));
+struct out_object {
+  std::unique_ptr<int> id;
+  std::string_view name;
+  next_obj_t obj;
+  REFLECTION_ALIAS(out_object, "qi", FLDALIAS(&out_object::id, "i"),
+                   FLDALIAS(&out_object::name, "na"),
+                   FLDALIAS(&out_object::obj, "obj"));
 };
-
 
 TEST_CASE("test alias") {
   out_object m{std::make_unique<int>(20), "tom", {21, 42}};
@@ -714,7 +716,7 @@ TEST_CASE("test alias") {
 
   out_object m1;
   iguana::from_xml(m1, xml_str);
-  CHECK(m1.name=="tom");
+  CHECK(m1.name == "tom");
   CHECK(m1.obj.x == 21);
   CHECK(m1.obj.y == 42);
 }


### PR DESCRIPTION
```c++
struct next_obj_t{
    int x;
    int y;
};
REFLECTION_ALIAS(next_obj_t, "next", FLDALIAS(&next_obj_t::x, "w"), FLDALIAS(&next_obj_t::y, "h"));

struct out_object{
    std::unique_ptr<int> id;
    std::string_view name;
    next_obj_t obj;
    REFLECTION_ALIAS(out_object, "qi", FLDALIAS(&out_object::id, "i"), FLDALIAS(&out_object::name, "na"), FLDALIAS(&out_object::obj, "obj"));
};
```

```c++
  out_object m{std::make_unique<int>(20), "tom", {21, 42}};
  std::string xml_str;
  iguana::to_xml(m, xml_str);

  out_object m1;
  iguana::from_xml(m1, xml_str);
  CHECK(m1.name=="tom");
  CHECK(m1.obj.x == 21);
  CHECK(m1.obj.y == 42);
```