### PR TITLE
support custom to_chars_float

### DIFF
--- a/example/json_example.cpp
+++ b/example/json_example.cpp
@@ -1,3 +1,16 @@
+#include <charconv>  // for to_chars
+#include <iostream>  // for std::cout
+
+namespace iguana {
+
+template <typename T>
+inline char* to_chars_float(T value, char* buffer) {
+  std::cout << "call custom to_chars_float with snprintf\n";
+  return buffer + snprintf(buffer, 65, "%g", value);
+}
+
+}  // namespace iguana
+
 #include <iguana/json_reader.hpp>
 #include <iguana/json_writer.hpp>
 
@@ -142,6 +155,19 @@ void user_defined_struct_example() {
   }
 }
 
+struct test_float_t {
+  double a;
+  float b;
+};
+REFLECTION(test_float_t, a, b);
+
+void user_defined_tochars_example() {
+  test_float_t t{2.011111, 2.54};
+  std::string ss;
+  iguana::to_json(t, ss);
+  std::cout << ss << std::endl;
+}
+
 int main(void) {
   test_disorder();
   test_v();
@@ -159,6 +185,6 @@ int main(void) {
   test_str_view();
 
   user_defined_struct_example();
-
+  user_defined_tochars_example();
   return 0;
 }

--- a/iguana/detail/charconv.h
+++ b/iguana/detail/charconv.h
@@ -55,7 +55,7 @@ char *to_chars(char *buffer, T value) noexcept {
   using U = std::decay_t<T>;
   if constexpr (std::is_floating_point_v<U>) {
     if constexpr (has_to_chars_float::value) {
-      return to_chars_float(value, buffer);
+      return static_cast<char *>(to_chars_float(value, buffer));
     }
     else {
       return jkj::dragonbox::to_chars(value, buffer);

--- a/iguana/detail/charconv.h
+++ b/iguana/detail/charconv.h
@@ -12,6 +12,18 @@ struct is_char_type
     : std::disjunction<std::is_same<T, char>, std::is_same<T, wchar_t>,
                        std::is_same<T, char16_t>, std::is_same<T, char32_t>> {};
 
+inline void *to_chars_float(...) {
+  throw std::runtime_error("not allowed to invoke");
+  return {};
+}
+
+template <typename T, typename Ret = decltype(to_chars_float(
+                          std::declval<T>(), std::declval<char *>()))>
+using return_of_tochars = std::conditional_t<std::is_same_v<Ret, char *>,
+                                             std::true_type, std::false_type>;
+// here std::true_type is used as a type , any other type is also ok.
+using has_to_chars_float = iguana::return_of_tochars<std::true_type>;
+
 namespace detail {
 
 // check_number==true: check if the string [first, last) is a legal number
@@ -42,7 +54,12 @@ template <typename T>
 char *to_chars(char *buffer, T value) noexcept {
   using U = std::decay_t<T>;
   if constexpr (std::is_floating_point_v<U>) {
-    return jkj::dragonbox::to_chars(value, buffer);
+    if constexpr (has_to_chars_float::value) {
+      return to_chars_float(value, buffer);
+    }
+    else {
+      return jkj::dragonbox::to_chars(value, buffer);
+    }
   }
   else if constexpr (std::is_signed_v<U> && (sizeof(U) >= 8)) {
     return xtoa(value, buffer, 10, 1);  // int64_t


### PR DESCRIPTION
example:

```c++
#include <charconv>  // for to_chars
#include <iostream>  // for std::cout

namespace iguana {

template <typename T>
inline char* to_chars_float(T value, char* buffer) {
  std::cout << "call custom to_chars_float with snprintf\n";
  return buffer + snprintf(buffer, 65, "%g", value);
}

}  // namespace iguana
#include <iguana/json_reader.hpp>
#include <iguana/json_writer.hpp>

struct test_float_t {
  double a;
  float b;
};
REFLECTION(test_float_t, a, b);

void user_defined_tochars_example() {
  test_float_t t{2.011111, 2.54};
  std::string ss;
  iguana::to_json(t, ss);
  std::cout << ss << std::endl;
}
int main(void) {
  user_defined_tochars_example();
  return 0;
}
```

