### PR TITLE
indexs_of, names_of

### DIFF
--- a/iguana/reflection.hpp
+++ b/iguana/reflection.hpp
@@ -958,12 +958,23 @@ constexpr size_t index_of() {
   return index;
 }
 
+template <auto... members>
+constexpr std::array<size_t, sizeof...(members)> indexs_of() {
+  return std::array<size_t, sizeof...(members)>{index_of<members>()...};
+}
+
 template <auto member>
 constexpr auto name_of() {
   using T = typename member_tratis<decltype(member)>::owner_type;
   using M = Reflect_members<T>;
   constexpr auto s = M::arr()[index_of<member>()];
   return std::string_view(s.data(), s.size());
+}
+
+template <auto... members>
+constexpr std::array<std::string_view, sizeof...(members)> names_of() {
+  return std::array<std::string_view, sizeof...(members)>{
+      name_of<members>()...};
 }
 
 template <auto member>

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -913,6 +913,12 @@ TEST_CASE("index_of name_of") {
   CHECK(idx1 == 1);
   CHECK(idx2 == 0);
 
+  constexpr auto index_arr = iguana::indexs_of<&point_t::x, &point_t::y>();
+  constexpr auto name_arr = iguana::names_of<&point_t::x, &point_t::y>();
+
+  CHECK(index_arr == std::array<size_t, 2>{0, 1});
+  CHECK(name_arr == std::array<std::string_view, 2>{"x", "y"});
+
   constexpr auto s1 = iguana::name_of<&point_t::y>();
   static_assert(s1 == "y");
   constexpr auto s2 = iguana::name_of<&person::name>();


### PR DESCRIPTION
```cpp
  constexpr auto index_arr = iguana::indexs_of<&point_t::x, &point_t::y>();
  constexpr auto name_arr = iguana::names_of<&point_t::x, &point_t::y>();

  CHECK(index_arr == std::array<size_t, 2>{0, 1});
  CHECK(name_arr == std::array<std::string_view, 2>{"x", "y"});
```