### PR TITLE
Fixed handling empty strings and lists in yaml

### DIFF
--- a/iguana/yaml_reader.hpp
+++ b/iguana/yaml_reader.hpp
@@ -254,10 +254,16 @@ IGUANA_INLINE void yaml_parse_item(U &value, It &&it, It &&end,
       }
     }
     else {
-      skip_space_and_lines(it, end, min_spaces);
-      auto start = it;
-      auto value_end = skip_till_newline(it, end);
-      yaml_parse_value(value, start, value_end);
+      auto indent = skip_space_and_lines<false>(it, end, min_spaces);
+      // in case of a string field it is valid for the field to have no content
+      if (indent < min_spaces) {
+        value = "";
+      }
+      else {
+        auto start = it;
+        auto value_end = skip_till_newline(it, end);
+        yaml_parse_value(value, start, value_end);
+      }
     }
   }
   else {

--- a/iguana/yaml_reader.hpp
+++ b/iguana/yaml_reader.hpp
@@ -173,6 +173,9 @@ IGUANA_INLINE void yaml_parse_value(U &value, It &&value_begin,
       IGUANA_UNLIKELY { throw std::runtime_error(R"(Expected ')"); }
   }
   value = T(&*start, static_cast<size_t>(std::distance(start, end)));
+  if ((value == "~") || (value == "null")) {
+    value = T{};
+  }
 }
 
 template <typename U, typename It, std::enable_if_t<char_v<U>, int> = 0>

--- a/iguana/yaml_util.hpp
+++ b/iguana/yaml_util.hpp
@@ -9,10 +9,10 @@ namespace iguana {
 template <typename T>
 constexpr inline bool yaml_not_support_v = variant_v<T>;
 
-// return true when it==end
+// skip non-linebreak whitespaces return true when it==end
 template <typename It>
 IGUANA_INLINE bool skip_space_till_end(It &&it, It &&end) {
-  while (it != end && (static_cast<uint8_t>(*it) < 33)) ++it;
+  while (it != end && (*it == ' ' || *it == '\t')) ++it;
   return it == end;
 }
 

--- a/iguana/yaml_writer.hpp
+++ b/iguana/yaml_writer.hpp
@@ -110,11 +110,16 @@ template <bool Is_writing_escape, typename Stream, typename T,
           std::enable_if_t<sequence_container_v<T>, int> = 0>
 IGUANA_INLINE void render_yaml_value(Stream &ss, const T &t,
                                      size_t min_spaces) {
-  ss.push_back('\n');
-  for (const auto &v : t) {
-    ss.append(min_spaces, ' ');
-    ss.append("- ");
-    render_yaml_value<Is_writing_escape>(ss, v, min_spaces + 1);
+  if (t.empty()) {
+    ss.append("[]");
+  }
+  else {
+    ss.push_back('\n');
+    for (const auto &v : t) {
+      ss.append(min_spaces, ' ');
+      ss.append("- ");
+      render_yaml_value<Is_writing_escape>(ss, v, min_spaces + 1);
+    }
   }
 }
 

--- a/iguana/yaml_writer.hpp
+++ b/iguana/yaml_writer.hpp
@@ -30,6 +30,9 @@ IGUANA_INLINE void render_yaml_value(Stream &ss, T &&t, size_t min_spaces) {
     write_string_with_escape(t.data(), t.size(), ss);
     ss.push_back('"');
   }
+  else if (t.size() == 0) {
+    ss.push_back('~');
+  }
   else {
     ss.append(t.data(), t.size());
   }

--- a/iguana/yaml_writer.hpp
+++ b/iguana/yaml_writer.hpp
@@ -112,6 +112,7 @@ IGUANA_INLINE void render_yaml_value(Stream &ss, const T &t,
                                      size_t min_spaces) {
   if (t.empty()) {
     ss.append("[]");
+    ss.push_back('\n');
   }
   else {
     ss.push_back('\n');

--- a/test/test_yaml.cpp
+++ b/test/test_yaml.cpp
@@ -945,6 +945,47 @@ b: test
   }
 }
 
+struct Empties_t {
+  std::string empty_tilde;
+  std::string empty_null;
+};
+YLT_REFL(Empties_t, empty_tilde, empty_null);
+
+TEST_CASE("test empty string") {
+  std::string str = R"(
+    empty_tilde: ~
+    empty_null: null
+  )";
+  auto validator = [](Empties_t &cont) {
+    CHECK(cont.empty_tilde == "");
+    CHECK(cont.empty_null == "");
+  };
+
+  Empties_t cont;
+  iguana::from_yaml(cont, str);
+  validator(cont);
+
+  {
+    std::string ss;
+    iguana::to_yaml(cont, ss);
+    Empties_t cont1;
+    iguana::from_yaml(cont1, ss);
+    validator(cont1);
+  }
+  {
+    cont.empty_tilde = "";
+    cont.empty_null = "";
+    std::string ss;
+    iguana::to_yaml<true>(cont, ss);
+    std::cout << ss << std::endl;
+    Empties_t cont1;
+    iguana::from_yaml(cont1, ss);
+    CHECK(cont1.empty_tilde == cont.empty_tilde);
+    CHECK(cont1.empty_null == cont.empty_null);
+  }
+}
+
+
 // doctest comments
 // 'function' : must be 'attribute' - see issue #182
 DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4007)

--- a/test/test_yaml.cpp
+++ b/test/test_yaml.cpp
@@ -985,6 +985,40 @@ TEST_CASE("test empty string") {
   }
 }
 
+struct EmptyList_t {
+  std::vector<int> empty_vector;
+};
+YLT_REFL(EmptyList_t, empty_vector);
+
+TEST_CASE("test empty vector") {
+  std::string str = R"(
+    empty_vector: []
+  )";
+  auto validator = [](EmptyList_t &cont) {
+    CHECK(cont.empty_vector.empty());
+  };
+
+  EmptyList_t cont;
+  iguana::from_yaml(cont, str);
+  validator(cont);
+
+  {
+    std::string ss;
+    iguana::to_yaml(cont, ss);
+    EmptyList_t cont1;
+    iguana::from_yaml(cont1, ss);
+    validator(cont1);
+  }
+  {
+    cont.empty_vector = {};
+    std::string ss;
+    iguana::to_yaml<true>(cont, ss);
+    EmptyList_t cont1;
+    iguana::from_yaml(cont1, ss);
+    CHECK(cont1.empty_vector == cont.empty_vector);
+  }
+}
+
 
 // doctest comments
 // 'function' : must be 'attribute' - see issue #182

--- a/test/test_yaml.cpp
+++ b/test/test_yaml.cpp
@@ -1024,7 +1024,6 @@ TEST_CASE("test empty vector") {
   }
 }
 
-
 // doctest comments
 // 'function' : must be 'attribute' - see issue #182
 DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4007)

--- a/test/test_yaml.cpp
+++ b/test/test_yaml.cpp
@@ -946,17 +946,20 @@ b: test
 }
 
 struct Empties_t {
+  std::string empty_empty;
   std::string empty_tilde;
   std::string empty_null;
 };
-YLT_REFL(Empties_t, empty_tilde, empty_null);
+YLT_REFL(Empties_t, empty_empty, empty_tilde, empty_null);
 
 TEST_CASE("test empty string") {
   std::string str = R"(
+    empty_empty:
     empty_tilde: ~
     empty_null: null
   )";
   auto validator = [](Empties_t &cont) {
+    CHECK(cont.empty_empty == "");
     CHECK(cont.empty_tilde == "");
     CHECK(cont.empty_null == "");
   };
@@ -973,6 +976,7 @@ TEST_CASE("test empty string") {
     validator(cont1);
   }
   {
+    cont.empty_empty = "";
     cont.empty_tilde = "";
     cont.empty_null = "";
     std::string ss;
@@ -980,6 +984,7 @@ TEST_CASE("test empty string") {
     std::cout << ss << std::endl;
     Empties_t cont1;
     iguana::from_yaml(cont1, ss);
+    CHECK(cont1.empty_empty == cont.empty_empty);
     CHECK(cont1.empty_tilde == cont.empty_tilde);
     CHECK(cont1.empty_null == cont.empty_null);
   }

--- a/test/test_yaml.cpp
+++ b/test/test_yaml.cpp
@@ -949,14 +949,19 @@ struct Empties_t {
   std::string empty_empty;
   std::string empty_tilde;
   std::string empty_null;
+  std::string tilde_word;
+  std::string null_word;
 };
-YLT_REFL(Empties_t, empty_empty, empty_tilde, empty_null);
+YLT_REFL(Empties_t, empty_empty, empty_tilde, empty_null, tilde_word,
+         null_word);
 
 TEST_CASE("test empty string") {
   std::string str = R"(
     empty_empty:
     empty_tilde: ~
     empty_null: null
+    tilde_word: "~"
+    null_word: "null"
   )";
   auto validator = [](Empties_t &cont) {
     CHECK(cont.empty_empty == "");
@@ -967,6 +972,8 @@ TEST_CASE("test empty string") {
   Empties_t cont;
   iguana::from_yaml(cont, str);
   validator(cont);
+  CHECK(cont.tilde_word == "~");
+  CHECK(cont.null_word == "null");
 
   {
     std::string ss;
@@ -987,17 +994,21 @@ TEST_CASE("test empty string") {
     CHECK(cont1.empty_empty == cont.empty_empty);
     CHECK(cont1.empty_tilde == cont.empty_tilde);
     CHECK(cont1.empty_null == cont.empty_null);
+    CHECK(cont1.tilde_word == cont.tilde_word);
+    CHECK(cont1.null_word == cont.null_word);
   }
 }
 
 struct EmptyList_t {
   std::vector<int> empty_vector;
+  std::vector<int> second_value;
 };
-YLT_REFL(EmptyList_t, empty_vector);
+YLT_REFL(EmptyList_t, empty_vector, second_value);
 
 TEST_CASE("test empty vector") {
   std::string str = R"(
     empty_vector: []
+    second_value: []
   )";
   auto validator = [](EmptyList_t &cont) {
     CHECK(cont.empty_vector.empty());
@@ -1016,6 +1027,7 @@ TEST_CASE("test empty vector") {
   }
   {
     cont.empty_vector = {};
+    cont.second_value = {};
     std::string ss;
     iguana::to_yaml<true>(cont, ss);
     EmptyList_t cont1;


### PR DESCRIPTION
Currently struct_yaml fails to deserialize its own serialization output if it contains a non-optional empty strings or non-optional empty vectors.

Further, yaml allows representing an empty string an ~ which was also not supported.