### PR TITLE
fix #362 ; support YLT_REFL_PB to replace YLT_REFL and get_members_impl

### DIFF
--- a/iguana/common.hpp
+++ b/iguana/common.hpp
@@ -214,15 +214,15 @@ inline auto build_pb_fields(const Array& offset_arr,
 template <typename T>
 inline auto get_pb_members_tuple(T&& t) {
   using U = ylt::reflection::remove_cvref_t<T>;
-  if constexpr (ylt_refletable_v<U>) {
+  if constexpr (is_custom_reflection_v<U>) {
+    return get_members_impl((U*)nullptr);
+  }
+  else if constexpr (ylt_refletable_v<U>) {
     static auto& offset_arr = ylt::reflection::internal::get_member_offset_arr(
         ylt::reflection::internal::wrapper<U>::value);
     using Tuple = decltype(ylt::reflection::object_to_tuple(std::declval<U>()));
     return build_pb_fields<Tuple, T>(
         offset_arr, std::make_index_sequence<std::tuple_size_v<Tuple>>{});
-  }
-  else if constexpr (is_custom_reflection_v<U>) {
-    return get_members_impl((U*)nullptr);
   }
   else {
     static_assert(!sizeof(T), "not a reflectable type");
@@ -243,6 +243,7 @@ inline auto get_members(T&& t) {
     static_assert(!sizeof(T), "expected reflection or custom reflection");
   }
 }
+
 }  // namespace detail
 
 template <typename T>

--- a/iguana/pb_util.hpp
+++ b/iguana/pb_util.hpp
@@ -586,5 +586,77 @@ IGUANA_INLINE size_t pb_value_size(Type&& t, uint32_t*& sz_ptr) {
   }
 }
 
+// YLT_REFL_PB implementation
+template <typename>
+struct pb_field_no;
+
+template <typename Owner, typename Value, size_t FieldNo, typename ElementType>
+struct pb_field_no<pb_field_t<Owner, Value, FieldNo, ElementType>> {
+  static constexpr size_t value = FieldNo;
+};
+
+template <typename T, size_t... I>
+inline auto build_pb_members_impl(
+    const std::array<size_t, sizeof...(I)>& offset_arr,
+    std::index_sequence<I...>) {
+  using Tuple = decltype(ylt::reflection::object_to_tuple(std::declval<T>()));
+  constexpr auto names = ylt::reflection::get_member_names<T>();
+  constexpr auto numbers = get_pb_field_numbers((T*)nullptr);
+  return std::tuple_cat(
+      build_pb_fields_impl<T, numbers[I] - 1, std::tuple_element_t<I, Tuple>>(
+          offset_arr[I], names[I])...);
+}
+
+template <typename Tuple, size_t... I>
+constexpr bool has_duplicate_field_nos(std::index_sequence<I...>) {
+  constexpr size_t nos[] = {
+      pb_field_no<std::tuple_element_t<I, Tuple>>::value...};
+  constexpr size_t N = sizeof...(I);
+  for (size_t i = 0; i < N; ++i)
+    for (size_t j = i + 1; j < N; ++j)
+      if (nos[i] == nos[j])
+        return true;
+  return false;
+}
+
+template <typename T>
+inline auto build_pb_members() {
+  using Tuple = decltype(ylt::reflection::object_to_tuple(std::declval<T>()));
+  constexpr size_t N = std::tuple_size_v<Tuple>;
+  static auto& offset_arr = ylt::reflection::internal::get_member_offset_arr(
+      ylt::reflection::internal::wrapper<T>::value);
+
+  auto res =
+      build_pb_members_impl<T>(offset_arr, std::make_index_sequence<N>{});
+  using ResultTuple = decltype(res);
+  constexpr size_t M = std::tuple_size_v<ResultTuple>;
+  static_assert(
+      !has_duplicate_field_nos<ResultTuple>(std::make_index_sequence<M>{}),
+      "YLT_REFL_PB: duplicate proto field numbers detected");
+  return res;
+}
+
+#define YLT_REFL_PB(STRUCT, ...)                                      \
+  IGUANA_PB_YLT_REFL_FWD(                                             \
+      STRUCT, WRAP_ARGS(IGUANA_PB_FIELD_NAME, unused, ##__VA_ARGS__)) \
+  inline constexpr auto get_pb_field_numbers(STRUCT*) {               \
+    return std::array<size_t, YLT_ARG_COUNT(__VA_ARGS__)>{            \
+        WRAP_ARGS(IGUANA_PB_FIELD_NO, unused, ##__VA_ARGS__)};        \
+  }                                                                   \
+  inline auto get_members_impl(STRUCT*) {                             \
+    return iguana::detail::build_pb_members<STRUCT>();                \
+  }
+
+#define IGUANA_PB_GET_FIELD_(field, no) field
+#define IGUANA_PB_GET_FIELD(pair) IGUANA_PB_GET_FIELD_ pair
+
+#define IGUANA_PB_GET_NO_(field, no) no
+#define IGUANA_PB_GET_NO(pair) IGUANA_PB_GET_NO_ pair
+
+#define IGUANA_PB_FIELD_NAME(unused, pair) IGUANA_PB_GET_FIELD(pair)
+#define IGUANA_PB_FIELD_NO(unused, pair) (size_t) IGUANA_PB_GET_NO(pair)
+
+#define IGUANA_PB_YLT_REFL_FWD(STRUCT, ...) YLT_REFL(STRUCT, __VA_ARGS__)
+
 }  // namespace detail
 }  // namespace iguana

--- a/test/test_pb.cpp
+++ b/test/test_pb.cpp
@@ -833,6 +833,89 @@ TEST_CASE("test variant") {
     CHECK(std::get<double>(st2.y) == 3.88);
   }
 }
+// hand-written get_members_impl
+struct Person362 {
+  std::string name;
+  int32_t age;
+  std::vector<std::string> emails;
+};
+inline auto get_members_impl(Person362 *) {
+  return std::make_tuple(
+      iguana::build_pb_field<&Person362::name, 10>("name"),
+      iguana::build_pb_field<&Person362::age, 20>("age"),
+      iguana::build_pb_field<&Person362::emails, 9>("emails"));
+}
+YLT_REFL(Person362, name, age, emails);
+
+// YLT_REFL_PB macro
+struct Person362Macro {
+  std::string name;
+  int32_t age;
+  std::vector<std::string> emails;
+};
+YLT_REFL_PB(Person362Macro, (name, 10), (age, 20), (emails, 9));
+
+TEST_CASE("test issue 362 custom field numbers") {
+  {
+    std::string str;
+    iguana::to_proto<Person362>(str, "Demo");
+    std::cout << str;
+    CHECK(str.find("syntax = \"proto3\";") != std::string::npos);
+    CHECK(str.find("package Demo;") != std::string::npos);
+    CHECK(str.find("message Person362") != std::string::npos);
+    CHECK(str.find("name = 10;") != std::string::npos);
+    CHECK(str.find("age = 20;") != std::string::npos);
+    CHECK(str.find("emails = 9;") != std::string::npos);
+
+    Person362 p1{"Alice", 30, {"a@b.com", "c@d.com"}};
+    std::string buf;
+    iguana::to_pb(p1, buf);
+    Person362 p2;
+    iguana::from_pb(p2, buf);
+    CHECK(p2.name == p1.name);
+    CHECK(p2.age == p1.age);
+    CHECK(p2.emails == p1.emails);
+
+    std::string json;
+    iguana::to_json(p1, json);
+    CHECK(json.find("\"name\"") != std::string::npos);
+    CHECK(json.find("\"age\"") != std::string::npos);
+  }
+
+  // ── Method 2: YLT_REFL_PB macro ──
+  {
+    std::string str;
+    iguana::to_proto<Person362Macro>(str, "Demo");
+    std::cout << str;
+    CHECK(str.find("syntax = \"proto3\";") != std::string::npos);
+    CHECK(str.find("package Demo;") != std::string::npos);
+    CHECK(str.find("message Person362Macro") != std::string::npos);
+    CHECK(str.find("name = 10;") != std::string::npos);
+    CHECK(str.find("age = 20;") != std::string::npos);
+    CHECK(str.find("emails = 9;") != std::string::npos);
+
+    Person362Macro p1{"Bob", 25, {"x@y.com"}};
+    std::string buf;
+    iguana::to_pb(p1, buf);
+    Person362Macro p2;
+    iguana::from_pb(p2, buf);
+    CHECK(p2.name == p1.name);
+    CHECK(p2.age == p1.age);
+    CHECK(p2.emails == p1.emails);
+
+    std::string json;
+    iguana::to_json(p1, json);
+    CHECK(json.find("\"name\"") != std::string::npos);
+    CHECK(json.find("\"age\"") != std::string::npos);
+
+    Person362 q1{"Bob", 25, {"x@y.com"}};
+    std::string buf1, buf2;
+    iguana::to_pb(q1, buf1);
+    iguana::to_pb(p1, buf2);
+    CHECK(buf1 == buf2);
+  }
+}
+
 #endif
 
 DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4007)


### PR DESCRIPTION
Fix to_proto field tag encoding and introduce YLT_REFL_PB macro

Closes #362.

Problem: When using to_proto, protobuf field numbers (tags) were being reset to sequential values {1, 2, 3, ...} regardless of the user-specified tags in the original .proto definition. This caused round-trip fidelity issues when non-sequential field numbers (e.g., name = 10, age = 20) were used.